### PR TITLE
changed setup mount check

### DIFF
--- a/picloud.sh
+++ b/picloud.sh
@@ -42,7 +42,7 @@ function setup() {
   mkdir /mnt/MyCloud
   echo "$automount" | tee -a /etc/fstab > /dev/null
 
-  if ! mount -a; then
+  if ! (mountpoint -q /mnt/MyCloud); then
     rmdir /mnt/MyCloud
     echo "Mounting MyCloud failed during setup"
     exit 1


### PR DESCRIPTION
This does what it did for backup. It is a more direct check of is something mounted on that path.